### PR TITLE
Don't delete all the records of a type changing apex value

### DIFF
--- a/ovh_dns.py
+++ b/ovh_dns.py
@@ -117,16 +117,13 @@ def get_domain_records(client, domain, fieldtype=None, subDomain=None):
     """Obtain all records for a specific domain"""
     records = {}
 
-    params = {
-        'subDomain': subDomain,
-        'fieldType': fieldtype,
-    }
+    params = {}
 
     # List all ids and then get info for each one
-    if not subDomain:
-        params.pop('subDomain')
-    if not fieldtype:
-        params.pop('fieldType')
+    if subDomain is not None:
+        params['subDomain'] = subDomain
+    if fieldtype is not None:
+        params['fieldType'] = fieldtype
 
     record_ids = client.get('/domain/zone/{}/record'.format(domain),
                             **params)


### PR DESCRIPTION
If you have a setup like:

```
     IN A      1.2.3.4
vps1 IN A      1.2.3.4
vps2 IN A      5.6.7.8
```

and you want to change the apex record, all the other A records would have been deleted.