### PR TITLE
root domain fix

### DIFF
--- a/ovh_dns.py
+++ b/ovh_dns.py
@@ -123,7 +123,7 @@ def get_domain_records(client, domain, fieldtype=None, subDomain=None):
     }
 
     # List all ids and then get info for each one
-    if not subDomain:
+    if subDomain == None:
         params.pop('subDomain')
     if not fieldtype:
         params.pop('fieldType')


### PR DESCRIPTION
If name: "" is used, subDomain was not set. This behavior can remove subdomains records as we want to modify root (name: "") records. Condition on subdomain is kept if name is not None.

My use-case : I have an TXT spf records both on my main domain and on a subdomain. Record update on my main domain deletes subdomain record as it is retrieved by current implementation of get_domain_records. This bug is not triggered if current record matches target one, as in this case ``module.exit_json(changed=False)`` is performed early.