### PR TITLE
Drop shebang from plugins

### DIFF
--- a/ovh_dns.py
+++ b/ovh_dns.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # ovh_dns, an Ansible module for managing OVH DNS records

--- a/ovh_reverse.py
+++ b/ovh_reverse.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # ovh_reverse, an Ansible module for managing OVH DNS reverse


### PR DESCRIPTION
Hello,

Not sure if it is or not a smart proposal, as my issue is linked with the way I use `ansible-ovh-dns`.

I use this repository as a submodule of my playbook/inventory repository, in a `library/` subfolder, and I customize ansible `library` path to add it. I also delegate all DNS task to localhost, as I prefer to execute queries from my controller. Last trick is that I use a virtualenv to launch `ansible-playbook` (so I do not need to interfere with my system's python install).

As I switch from ansible 5.2 to 6.5, it happens that ansible starts to honor shebang, and so run `ovh_*.py` scripts with `/usr/bin/env python` command and fails as `ovh` package is not installed on my system's python. With ansible 5.2, it used my `ansible_python_interpreter` that targets my ovh-enabled virtualenv.

If I drop shebang lines as proposed in this PR, previous behavior (`ansible_python_interpreter` is honored) is restored.