### PR TITLE
Escape the name when removing an entry

### DIFF
--- a/ovh_dns.py
+++ b/ovh_dns.py
@@ -204,7 +204,7 @@ def main():
         if removes:
             rn = re.compile(removes, re.IGNORECASE)
         else:
-            rn = re.compile("^{}$".format(name), re.IGNORECASE)
+            rn = re.compile("^{}$".format(re.escape(name)), re.IGNORECASE)
         if targetval:
             rv = re.compile(targetval, re.IGNORECASE)
         else:


### PR DESCRIPTION
Without this, `state=absent name=* domain=…` fails because `^*$` is not a valid regexp.

To reproduce:
```yaml
    - name: test setup
      ovh_dns:
        state: present
        domain: example.com
        name: '*.foo'
        type: A
        value: '127.0.0.1'

    - name: test
      ovh_dns:
        state: absent
        domain: example.com
        name: '*.foo'
        type: A
        value: '127.0.0.1'
```
Replace `example.com` with your domain.

Output:
```
TASK [test setup] *****************************************************************************************************************************************
changed: [localhost]

TASK [test] ***********************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: re.error: nothing to repeat at position 1
fatal: [localhost]: FAILED! => changed=false 
  module_stderr: |-
    Traceback (most recent call last):
      File "<stdin>", line 107, in <module>
      File "<stdin>", line 99, in _ansiballz_main
      File "<stdin>", line 47, in invoke_module
      File "<frozen runpy>", line 226, in run_module
      File "<frozen runpy>", line 98, in _run_module_code
      File "<frozen runpy>", line 88, in _run_code
      File "/tmp/ansible_ovh_dns_payload_olgqqj9c/ansible_ovh_dns_payload.zip/ansible/modules/ovh_dns.py", line 352, in <module>
      File "/tmp/ansible_ovh_dns_payload_olgqqj9c/ansible_ovh_dns_payload.zip/ansible/modules/ovh_dns.py", line 207, in main
      File "/home/linuxbrew/.linuxbrew/opt/python@3.11/lib/python3.11/re/__init__.py", line 227, in compile
        return _compile(pattern, flags)
               ^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/linuxbrew/.linuxbrew/opt/python@3.11/lib/python3.11/re/__init__.py", line 294, in _compile
        p = _compiler.compile(pattern, flags)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/linuxbrew/.linuxbrew/opt/python@3.11/lib/python3.11/re/_compiler.py", line 745, in compile
        p = _parser.parse(p, flags)
            ^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/linuxbrew/.linuxbrew/opt/python@3.11/lib/python3.11/re/_parser.py", line 989, in parse
        p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/linuxbrew/.linuxbrew/opt/python@3.11/lib/python3.11/re/_parser.py", line 464, in _parse_sub
        itemsappend(_parse(source, state, verbose, nested + 1,
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/linuxbrew/.linuxbrew/opt/python@3.11/lib/python3.11/re/_parser.py", line 691, in _parse
        raise source.error("nothing to repeat",
    re.error: nothing to repeat at position 1
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
  rc: 1
```

This also fixes potential bugs due to unescaped dots: `name=a.c` currently matches both `a.c.DOMAIN` and `abc.DOMAIN`.